### PR TITLE
Overhaul inventory editing

### DIFF
--- a/data/ensconcer/functions/inventory/copy_jukebox_to_shulker.mcfunction
+++ b/data/ensconcer/functions/inventory/copy_jukebox_to_shulker.mcfunction
@@ -1,5 +1,0 @@
-# clear shulker box
-data modify block 654321 0 654322 Items set value []
-
-# copy inventory to shulker box for editing and remove appropriate slots from temporary inventory
-function ensconcer:inventory/copy_jukebox_to_shulker/step

--- a/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/below_max.mcfunction
+++ b/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/below_max.mcfunction
@@ -1,3 +1,0 @@
-execute if score $ensconcer.slot workspace >= $ensconcer.minslot workspace run function ensconcer:inventory/copy_jukebox_to_shulker/in_range
-data remove block 654321 0 654321 RecordItem.tag.ensconcer.Inventory[0]
-function ensconcer:inventory/copy_jukebox_to_shulker/step

--- a/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/get_slot.mcfunction
+++ b/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/get_slot.mcfunction
@@ -1,4 +1,0 @@
-execute store result score $ensconcer.slot workspace run data get block 654321 0 654321 RecordItem.tag.ensconcer.Inventory[0].Slot
-# convert overflow negatives to positive
-execute if score $ensconcer.slot workspace matches ..-1 run scoreboard players add $ensconcer.slot workspace 256
-execute if score $ensconcer.slot workspace <= $ensconcer.maxslot workspace run function ensconcer:inventory/copy_jukebox_to_shulker/below_max

--- a/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/in_range.mcfunction
+++ b/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/in_range.mcfunction
@@ -1,3 +1,0 @@
-scoreboard players operation $ensconcer.slot workspace -= $ensconcer.minslot workspace
-execute store result block 654321 0 654321 RecordItem.tag.ensconcer.Inventory[0].Slot byte 1 run scoreboard players get $ensconcer.slot workspace
-data modify block 654321 0 654322 Items append from block 654321 0 654321 RecordItem.tag.ensconcer.Inventory[0]

--- a/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/step.mcfunction
+++ b/data/ensconcer/functions/inventory/copy_jukebox_to_shulker/step.mcfunction
@@ -1,2 +1,0 @@
-execute store result score $ensconcer.slotcount workspace run data get block 654321 0 654321 RecordItem.tag.ensconcer.Inventory
-execute if score $ensconcer.slotcount workspace matches 1.. run function ensconcer:inventory/copy_jukebox_to_shulker/get_slot

--- a/data/ensconcer/functions/inventory/order.mcfunction
+++ b/data/ensconcer/functions/inventory/order.mcfunction
@@ -1,5 +1,0 @@
-function ensconcer:inventory/start_editing
-function ensconcer:inventory/step/hotbar_to_inventory
-function ensconcer:inventory/step/inventory_to_armor
-function ensconcer:inventory/step/armor_to_offhand
-function ensconcer:inventory/finish_editing

--- a/data/ensconcer/functions/inventory/start_editing.mcfunction
+++ b/data/ensconcer/functions/inventory/start_editing.mcfunction
@@ -1,7 +1,0 @@
-# copy inventory to the jukebox for temporary storage
-data modify block 654321 0 654321 RecordItem.tag.ensconcer.Inventory set from entity @s Inventory
-
-# copy hotbar
-scoreboard players set $ensconcer.minslot workspace 0
-scoreboard players set $ensconcer.maxslot workspace 8
-function ensconcer:inventory/copy_jukebox_to_shulker

--- a/data/ensconcer/functions/inventory/step/armor_to_offhand.mcfunction
+++ b/data/ensconcer/functions/inventory/step/armor_to_offhand.mcfunction
@@ -1,7 +1,0 @@
-# save previous inventory section
-drop entity @s armor.feet 4 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
-
-# copy next section
-scoreboard players set $ensconcer.minslot workspace 150
-scoreboard players set $ensconcer.maxslot workspace 150
-function ensconcer:inventory/copy_jukebox_to_shulker

--- a/data/ensconcer/functions/inventory/step/hotbar_to_inventory.mcfunction
+++ b/data/ensconcer/functions/inventory/step/hotbar_to_inventory.mcfunction
@@ -1,7 +1,0 @@
-# save previous inventory section
-drop entity @s hotbar.0 9 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
-
-# copy next section
-scoreboard players set $ensconcer.minslot workspace 9
-scoreboard players set $ensconcer.maxslot workspace 35
-function ensconcer:inventory/copy_jukebox_to_shulker

--- a/data/ensconcer/functions/inventory/step/inventory_to_armor.mcfunction
+++ b/data/ensconcer/functions/inventory/step/inventory_to_armor.mcfunction
@@ -1,7 +1,0 @@
-# save previous inventory section
-drop entity @s inventory.0 27 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
-
-# copy next section
-scoreboard players set $ensconcer.minslot workspace 100
-scoreboard players set $ensconcer.maxslot workspace 103
-function ensconcer:inventory/copy_jukebox_to_shulker

--- a/data/ensconcer/functions/modifyinv/apply_armor.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_armor.mcfunction
@@ -1,0 +1,2 @@
+# Apply first 4 slots of shulker box inventory to player armor slots, replacing them:
+drop entity @s armor.legs 4 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/apply_armor.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_armor.mcfunction
@@ -1,2 +1,2 @@
 # Apply first 4 slots of shulker box inventory to player armor slots, replacing them:
-drop entity @s armor.legs 4 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
+drop entity @s armor.feet 4 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/apply_hotbar.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_hotbar.mcfunction
@@ -1,0 +1,2 @@
+# Apply first 9 slots of shulker box inventory to player hotbar slots, replacing them:
+drop entity @s hotbar.0 9 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/apply_inventory.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_inventory.mcfunction
@@ -1,0 +1,2 @@
+# Apply shulker box inventory to player inventory slots, replacing them:
+drop entity @s inventory.0 27 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/apply_offhand.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_offhand.mcfunction
@@ -1,2 +1,2 @@
-# save previous inventory section
+# Apply first shulker box slot to player offhand slot, replacing it:
 drop entity @s weapon.offhand 1 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/cleanup.mcfunction
+++ b/data/ensconcer/functions/modifyinv/cleanup.mcfunction
@@ -1,0 +1,9 @@
+# Remove temporary data used by this module:
+scoreboard players reset $modifyinv.slot workspace
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.inventory
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.hotbar
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.armor
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.offhand
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.enderchest
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory
+data modify block 654321 0 654322 Items set value []

--- a/data/ensconcer/functions/modifyinv/load_armor.mcfunction
+++ b/data/ensconcer/functions/modifyinv/load_armor.mcfunction
@@ -1,0 +1,2 @@
+# Load armor items into shulker box so they can be modified and applied:
+data modify block 654321 0 654322 Items set from block 654321 0 654321 RecordItem.tag.ensconcer.armor

--- a/data/ensconcer/functions/modifyinv/load_hotbar.mcfunction
+++ b/data/ensconcer/functions/modifyinv/load_hotbar.mcfunction
@@ -1,0 +1,2 @@
+# Load hotbar items into shulker box so they can be modified and applied:
+data modify block 654321 0 654322 Items set from block 654321 0 654321 RecordItem.tag.ensconcer.hotbar

--- a/data/ensconcer/functions/modifyinv/load_inventory.mcfunction
+++ b/data/ensconcer/functions/modifyinv/load_inventory.mcfunction
@@ -1,0 +1,2 @@
+# Load inventory items into shulker box so they can be modified and applied:
+data modify block ~ ~ ~ Items set from block ~ ~-1 ~ RecordItem.tag.ensconcer.inventory

--- a/data/ensconcer/functions/modifyinv/load_offhand.mcfunction
+++ b/data/ensconcer/functions/modifyinv/load_offhand.mcfunction
@@ -1,0 +1,2 @@
+# Load offhand item into shulker box so it can be modified and applied:
+data modify block 654321 0 654322 Items set from block 654321 0 654321 RecordItem.tag.ensconcer.offhand

--- a/data/ensconcer/functions/modifyinv/setup_enderchest.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_enderchest.mcfunction
@@ -1,0 +1,2 @@
+# Copy player ender chest data to jukebox so it can be loaded.
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.enderchest set from entity @s EnderItems

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory.mcfunction
@@ -1,0 +1,13 @@
+# Copy player inventory data to jukebox and sort into sections so they can be loaded.
+
+# Reset sections:
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.inventory set value []
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.hotbar set value []
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.armor set value []
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.offhand set value []
+
+# Copy whole inventory data:
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory set from entity @s Inventory
+
+# Sort the slots into sections:
+function ensconcer:modifyinv/setup_whole_inventory/sort_slots

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_armor.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_armor.mcfunction
@@ -1,0 +1,2 @@
+# Check whether slot number matches an armor slot:
+execute if score $modifyinv.slot workspace matches 100..103 run function ensconcer:modifyinv/setup_whole_inventory/found_armor

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_hotbar.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_hotbar.mcfunction
@@ -1,0 +1,2 @@
+# Check whether slot number matches a hotbar slot:
+execute if score $modifyinv.slot workspace matches 0..8 run function ensconcer:modifyinv/setup_whole_inventory/found_hotbar

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_inventory.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_inventory.mcfunction
@@ -1,0 +1,2 @@
+# Check whether slot number matches an inventory slot:
+execute if score $modifyinv.slot workspace matches 9..35 run function ensconcer:modifyinv/setup_whole_inventory/found_inventory

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_offhand.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/check_offhand.mcfunction
@@ -1,0 +1,2 @@
+# Check whether slot number matches the offhand slot:
+execute if score $modifyinv.slot workspace matches -106 run function ensconcer:modifyinv/setup_whole_inventory/found_offhand

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_armor.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_armor.mcfunction
@@ -1,0 +1,10 @@
+# Remove 100 from the slot number so it will fit inside a shulker box:
+execute store result block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0].Slot byte 1 run scoreboard players remove $modifyinv.slot workspace 100
+
+# Move item into the armor section:
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.armor append from block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+
+# Get the slot number for the next item and repeat:
+execute store result score $modifyinv.slot workspace run data get block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0].Slot
+function ensconcer:modifyinv/setup_whole_inventory/check_armor

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_hotbar.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_hotbar.mcfunction
@@ -1,0 +1,7 @@
+# Move item into the hotbar section:
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.hotbar append from block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+
+# Get the slot number for the next item and repeat:
+execute store result score $modifyinv.slot workspace run data get block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0].Slot
+function ensconcer:modifyinv/setup_whole_inventory/check_hotbar

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_inventory.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_inventory.mcfunction
@@ -1,0 +1,10 @@
+# Remove 9 from the slot number so it will fit inside a shulker box:
+execute store result block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0].Slot byte 1 run scoreboard players remove $modifyinv.slot workspace 9
+
+# Move item into the inventory section:
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.inventory append from block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+
+# Get the slot number for the next item and repeat:
+execute store result score $modifyinv.slot workspace run data get block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0].Slot
+function ensconcer:modifyinv/setup_whole_inventory/check_inventory

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_offhand.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/found_offhand.mcfunction
@@ -1,0 +1,8 @@
+# Add 106 to the slot number so it will fit inside a shulker box:
+execute store result block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0].Slot byte 1 run scoreboard players add $modifyinv.slot workspace 106
+
+# Move item into the offhand section:
+data modify block 654321 0 654321 RecordItem.tag.ensconcer.offhand append from block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+data remove block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0]
+
+# (This should be the last item, so don't prepare for another.)

--- a/data/ensconcer/functions/modifyinv/setup_whole_inventory/sort_slots.mcfunction
+++ b/data/ensconcer/functions/modifyinv/setup_whole_inventory/sort_slots.mcfunction
@@ -1,0 +1,8 @@
+# Get the first slot number in preparation:
+execute store result score $modifyinv.slot workspace run data get block 654321 0 654321 RecordItem.tag.ensconcer.whole_inventory[0].Slot
+
+# Check all the sections in turn, sorting them (slots always appear in order):
+function ensconcer:modifyinv/setup_whole_inventory/check_hotbar
+function ensconcer:modifyinv/setup_whole_inventory/check_inventory
+function ensconcer:modifyinv/setup_whole_inventory/check_armor
+function ensconcer:modifyinv/setup_whole_inventory/check_offhand


### PR DESCRIPTION
Renames the module to `modifyinv`.
Changes sorting to happen independently of loading.
Creates easier to use public functions for use by data pack makers.