### PR TITLE
Replace drop commands with loot commands

### DIFF
--- a/data/ensconcer/functions/modifyinv/apply_armor.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_armor.mcfunction
@@ -1,2 +1,2 @@
 # Apply first 4 slots of shulker box inventory to player armor slots, replacing them:
-drop entity @s armor.feet 4 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
+loot replace entity @s armor.feet 4 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/apply_hotbar.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_hotbar.mcfunction
@@ -1,2 +1,2 @@
 # Apply first 9 slots of shulker box inventory to player hotbar slots, replacing them:
-drop entity @s hotbar.0 9 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
+loot replace entity @s hotbar.0 9 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/apply_inventory.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_inventory.mcfunction
@@ -1,2 +1,2 @@
 # Apply shulker box inventory to player inventory slots, replacing them:
-drop entity @s inventory.0 27 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
+loot replace entity @s inventory.0 27 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}

--- a/data/ensconcer/functions/modifyinv/apply_offhand.mcfunction
+++ b/data/ensconcer/functions/modifyinv/apply_offhand.mcfunction
@@ -1,2 +1,2 @@
 # Apply first shulker box slot to player offhand slot, replacing it:
-drop entity @s weapon.offhand 1 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}
+loot replace entity @s weapon.offhand 1 mine 654321 0 654322 minecraft:golden_pickaxe{drop_contents:true}


### PR DESCRIPTION
18w45a replaced `drop` with `loot` and slightly changed the syntax. This commit updates the affected commands.