### PR TITLE
One burrow per dimension

### DIFF
--- a/data/ensconcer/functions/check_chunk_loaded.mcfunction
+++ b/data/ensconcer/functions/check_chunk_loaded.mcfunction
@@ -1,9 +1,17 @@
 # Compare block to itself to check if chunk loaded
-execute store result score $ensconcer.chunk_loaded temp if blocks -30000000 0 1600 -30000000 0 1600 -30000000 0 1600 all 
+execute store success score $ensconcer.chunk_loaded temp if blocks -30000000 0 1600 -30000000 0 1600 -30000000 0 1600 all 
 
 # If still not loaded, prompt player and schedule self again 
-execute if score $ensconcer.chunk_loaded temp matches 0 run tellraw @a {"text":"Almost done, click here to complete datapack setup!","color":"dark_aqua","clickEvent":{"action":"run_command","value":"/forceload add -30000000 1600"}}
+execute if score $ensconcer.chunk_loaded temp matches 0 run tellraw @a {"text":"Almost done, click here to complete datapack setup!","color":"dark_aqua","clickEvent":{"action":"run_command","value":"/execute at @e[type=area_effect_cloud,tag=ensconcer.ld] run forceload add -30000000 1600"}}
 execute if score $ensconcer.chunk_loaded temp matches 0 run schedule function ensconcer:check_chunk_loaded 5s
 
+summon area_effect_cloud ~ ~ ~ {Tags:["ensconcer.ld","ensconcer.ld.overworld"],Duration:100}
+summon area_effect_cloud ~ ~ ~ {Tags:["ensconcer.ld","ensconcer.ld.nether"],Duration:100}
+summon area_effect_cloud ~ ~ ~ {Tags:["ensconcer.ld","ensconcer.ld.end"],Duration:100}
+execute in the_nether run tp @e[type=area_effect_cloud,tag=ensconcer.ld.nether,limit=1] ~ ~ ~
+execute in the_end run tp @e[type=area_effect_cloud,tag=ensconcer.ld.end,limit=1] ~ ~ ~
+execute as @e[type=area_effect_cloud,tag=ensconcer.ld] at @s run spreadplayers ~ ~ 0 1 false @s
+
 # Chunk has been loaded:
-execute if score $ensconcer.chunk_loaded temp matches 1 run function ensconcer:create_burrow
+execute if score $ensconcer.chunk_loaded temp matches 1 at @e[type=area_effect_cloud,tag=ensconcer.ld] run function ensconcer:create_burrow
+execute if score $ensconcer.chunk_loaded temp matches 1 run function ensconcer:setup_complete

--- a/data/ensconcer/functions/create_burrow.mcfunction
+++ b/data/ensconcer/functions/create_burrow.mcfunction
@@ -1,12 +1,8 @@
-scoreboard players set $ensconcer.initiated eglobal 1
-tellraw @a {"text":"Datapack setup complete!","color":"dark_aqua"}
-
 # Set up stuff in the chunk
 setblock -30000000 0 1600 minecraft:jukebox{RecordItem:{id:"minecraft:comparator",Count:1,tag:{}}}
-setblock -30000000 0 1601 minecraft:repeating_command_block[facing=north]{Command:"function ensconcer:after_entity_processing",auto:1b}
+execute in overworld run setblock -30000000 0 1601 minecraft:repeating_command_block[facing=north]{Command:"function #ensconcer:overworld_tick",auto:1b}
+execute in the_nether run setblock -30000000 0 1601 minecraft:repeating_command_block[facing=north]{Command:"function #ensconcer:nether_tick",auto:1b}
+execute in the_end run setblock -30000000 0 1601 minecraft:repeating_command_block[facing=north]{Command:"function #ensconcer:end_tick",auto:1b}
 setblock -30000000 0 1602 minecraft:shulker_box
 setblock -30000000 0 1603 minecraft:oak_wall_sign[facing=south]
 fill -30000000 1 1600 -30000000 1 1615 minecraft:bedrock
-
-# Notify any datapacks that care
-function #ensconcer:initiated

--- a/data/ensconcer/functions/create_helper_entity.mcfunction
+++ b/data/ensconcer/functions/create_helper_entity.mcfunction
@@ -1,0 +1,3 @@
+execute store success score $encsoncer.result temp run tp ec-0-0-0-1 ~ ~ ~
+execute if score $encsoncer.result temp matches 0 run summon area_effect_cloud ~ ~ ~ {Duration:-1,Age:-2147483648,WaitTime:-2147483648,UUIDMost:1013612281856L,UUIDLeast:1L,Tags:["ensconcer.ec.0.0.0.1"]}
+execute if score $encsoncer.result temp matches 1 run tag ec-0-0-0-1 add ensconcer.ec.0.0.0.1

--- a/data/ensconcer/functions/setup_complete.mcfunction
+++ b/data/ensconcer/functions/setup_complete.mcfunction
@@ -1,0 +1,5 @@
+scoreboard players set $ensconcer.initiated eglobal 1
+tellraw @a {"text":"Datapack setup complete!","color":"dark_aqua"}
+
+# Notify any datapacks that care
+function #ensconcer:initiated

--- a/data/ensconcer/tags/functions/end_tick.json
+++ b/data/ensconcer/tags/functions/end_tick.json
@@ -1,0 +1,6 @@
+{
+   "values": [
+      "#ensconcer:dimension_tick",
+      "ensconcer:create_helper_entity"
+   ]
+}

--- a/data/ensconcer/tags/functions/nether_tick.json
+++ b/data/ensconcer/tags/functions/nether_tick.json
@@ -1,0 +1,6 @@
+{
+   "values": [
+      "#ensconcer:dimension_tick",
+      "ensconcer:create_helper_entity"
+   ]
+}

--- a/data/ensconcer/tags/functions/overworld_tick.json
+++ b/data/ensconcer/tags/functions/overworld_tick.json
@@ -1,0 +1,6 @@
+{
+   "values": [
+      "#ensconcer:dimension_tick",
+      "ensconcer:create_helper_entity"
+   ]
+}


### PR DESCRIPTION
This adds one burrow to every dimension, primarily for the ability to get the unique command block tick time for *all* dimensions, not just the overworld.

To avoid requiring the user to click three messages to forceload three chunks, we create a temporary entity per dimension to does the work via `/execute at`. They are continually spread to ensure they can be targeted when the user gets around to clicking. I tested this a few times but it may not be foolproof.

There are also some new "API" tags. Each command block runs its own dimension tag, as well as a shared tag that all command blocks run.