### PR TITLE
Attempt to fix log spam once and for all

### DIFF
--- a/phi.core/src/datapack/data/phi.core/advancements/internal/tick_end.json
+++ b/phi.core/src/datapack/data/phi.core/advancements/internal/tick_end.json
@@ -9,9 +9,6 @@
         },
         "enter_block": {
             "trigger": "minecraft:enter_block"
-        },
-        "keep": {
-            "trigger": "minecraft:enter_block"
         }
     }
 }

--- a/phi.core/src/datapack/data/phi.core/functions/internal/fully_loaded_tick.mcfunction
+++ b/phi.core/src/datapack/data/phi.core/functions/internal/fully_loaded_tick.mcfunction
@@ -1,8 +1,6 @@
 # Modified and simplified from Arcensoth's tickbuster pack (https://github.com/Arcensoth/tickbuster-datapack)
 # Make sure the tick_end advancement can be obtained every tick. Done here so that it doesn't trigger multiple times in one tick
-# Avoid warnings flooding the log by keeping at least one criteria
-advancement revoke @a only phi.core:internal/tick_end enter_block
-advancement revoke @a only phi.core:internal/tick_end host
+advancement revoke @a only phi.core:internal/tick_end
 
 # Choose an arbitrary player as the host for this tick.
 advancement grant @a[sort=arbitrary,limit=1] only phi.core:internal/tick_end host

--- a/phi.core/src/datapack/data/phi.core/functions/internal/tick_end.mcfunction
+++ b/phi.core/src/datapack/data/phi.core/functions/internal/tick_end.mcfunction
@@ -1,1 +1,5 @@
+# Revoke the host advancement here as well which seems to avoid the log spam.
+# See: https://github.com/Arcensoth/tickbuster-datapack/issues/1
+advancement revoke @a only phi.core:internal/tick_end
+
 function #phi.core:tick_end


### PR DESCRIPTION
See: https://github.com/Arcensoth/tickbuster-datapack/issues/1

Here's what the log used to look like:

![image](https://camo.githubusercontent.com/8a8763e0a9a487229f486c9ab83f873cbb2fff3d/68747470733a2f2f692e696d6775722e636f6d2f624b72453159612e706e67)

Here's what it looks like now:

![image](https://cdn.discordapp.com/attachments/507646576521510934/600065765894258688/unknown.png)

I don't know why this solution started working in 1.14 but I ain't gonna complain.